### PR TITLE
Bootstrap confidence intervals

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -1,20 +1,25 @@
 import argparse
 import csv
 import concurrent.futures
+import enlighten
+import multiprocessing.shared_memory
+import matplotlib
 import numpy as np
 import pandas as pd
-import progress.bar
 import scipy.stats
 import sys
 import tempfile
+import threading
 from contextlib import contextmanager
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_agg import FigureCanvasAgg
-from typing import Dict, Tuple, Optional
+from typing import Callable, Dict, List, Tuple, Optional, Any
 from pathlib import Path
 
 
 class BinarySamplesFileLoader:
+    """Loads binary samples as from memory-mapped file"""
+
     def __init__(self, path: Path, nsamples: int, nclasses: int, dtype: np.dtype):
         self.file_path = path
         self.nsamples = nsamples
@@ -56,9 +61,9 @@ def _convert_samples_csv_to_bin(
 ) -> BinarySamplesFileLoader:
     """Converts the timing samples CSV file to a file in binary format.
 
-    This allows the samples to be memory mapped into multiple worker processes
-    and therefore avoid excessive memory usage when dealing with large sample
-    sets and many CPU cores.
+    Using a binary file format instead of CSV allows the samples to be memory
+    mapped into multiple worker processes and therefore avoid excessive memory
+    usage when dealing with large sample sets and many CPU cores.
 
     Parameters
     ----------
@@ -81,7 +86,9 @@ def _convert_samples_csv_to_bin(
         ncols = len(csv_reader.read(1).columns)
 
     # Load the CSV file in chunks to limit the peak memory usage
-    with pd.read_csv(samples_csv_path, chunksize=512000, dtype=dtype) as csv_reader:
+    with pd.read_csv(
+        samples_csv_path, chunksize=512000, dtype=dtype, header=None
+    ) as csv_reader:
         nrows = 0
         for chunk in csv_reader:
             nrows_in_chunk = len(chunk.index)
@@ -170,7 +177,6 @@ def _friedman_test(samples_bin: BinarySamplesFileLoader):
     ----------
     samples_bin
         File containing the samples in binary format.
-
     """
     with samples_bin.load_samples() as samples:
         nclasses = samples.shape[1]
@@ -198,7 +204,7 @@ def _draw_samples_scatter_plot(filename: Path, samples_bin: BinarySamplesFileLoa
 
         ax.set_title("Samples scatter plot")
         ax.set_xlabel("Sample index")
-        ax.set_ylabel("Time")
+        ax.set_ylabel("Cycles")
         ax.set_yscale("log")
 
         header = list(range(nclasses))
@@ -229,7 +235,7 @@ def _draw_class_means_plot(filename: Path, samples_bin: BinarySamplesFileLoader)
         ax.set_title("Class means")
         ax.set_xlabel("Class index")
         ax.set_xticks(list(range(nclasses)))
-        ax.set_ylabel("Time")
+        ax.set_ylabel("Cycles")
         ax.set_yscale("log")
         ax.set_ylim(auto=False)
 
@@ -246,7 +252,6 @@ def _draw_classes_box_plot(filename: Path, samples_bin: BinarySamplesFileLoader)
     ----------
     filename
         Path to the PNG file to generate.
-
     samples_bin
         File containing the samples in binary format.
     """
@@ -259,7 +264,7 @@ def _draw_classes_box_plot(filename: Path, samples_bin: BinarySamplesFileLoader)
 
         ax.set_title("Samples box plot")
         ax.set_xlabel("Class index")
-        ax.set_ylabel("Time")
+        ax.set_ylabel("Cycles")
         ax.set_yscale("log")
         percentiles = np.quantile(
             samples, [0.05, 0.25, 0.5, 0.75, 0.95], overwrite_input=False, axis=0
@@ -373,6 +378,305 @@ def _worst_pair(
     return worst_pair, worst_results
 
 
+def _resample(samples):
+    """Create a resample of the provided samples with the same length."""
+    return np.random.choice(samples, replace=True, size=len(samples))
+
+
+def _trimean(quartile1, median, quartile3):
+    """Calculate the statistical trimean."""
+    return (quartile1 + (median * 2) + quartile3) / 4
+
+
+def _central_tendencies_of_random_samples(
+    shared_mem: multiprocessing.shared_memory.SharedMemory,
+    shape,
+    dtype: np.dtype,
+    num_resamples: int,
+) -> Dict[str, List[float]]:
+    """Calculate the central tendencies of multiple resamplings of some data.
+
+    This function is intended to be called in a subprocess, so the samples are
+    passed in a shared memory buffer for efficiency.
+
+    Parameters
+    ----------
+    shared_mem
+        The shared memory buffer containing the samples to process.
+    shape
+        The shape of the numpy array in the shared_mem buffer.
+    dtype
+        The dtype of the numpy array elements in the shared_mem buffer.
+    num_resamples
+        The number of resamplings to perform.
+
+    Returns
+    -------
+    The dict which maps a central tendency name to the list of values (one
+    value per resampling).
+    """
+
+    samples = np.ndarray(shape, dtype, buffer=shared_mem.buf)
+
+    means = []
+    medians = []
+    trimmed_means_5pc = []
+    trimmed_means_25pc = []
+    trimmed_means_45pc = []
+    trimeans = []
+
+    for _ in range(num_resamples):
+        resampled = _resample(samples)
+
+        q1, median, q3 = np.quantile(resampled, [0.25, 0.5, 0.75])
+
+        means.append(np.mean(resampled))
+        medians.append(median)
+        trimmed_means_5pc.append(scipy.stats.trim_mean(resampled, 0.05))
+        trimmed_means_25pc.append(scipy.stats.trim_mean(resampled, 0.25))
+        trimmed_means_45pc.append(scipy.stats.trim_mean(resampled, 0.45))
+        trimeans.append(_trimean(q1, median, q3))
+
+    return {
+        "mean": means,
+        "median": medians,
+        "trimmed_mean_5pc": trimmed_means_5pc,
+        "trimmed_mean_25pc": trimmed_means_25pc,
+        "trimmed_mean_45pc": trimmed_means_45pc,
+        "trimean": trimeans,
+    }
+
+
+def _bootstrap_central_tendencies_of_differences(
+    samples: np.ndarray,
+    class1: int,
+    class2: int,
+    num_resamples: int,
+    submit_job: Callable[[Callable, Any], concurrent.futures.Future],
+) -> Tuple[Dict[str, float], Dict[str, List[float]]]:
+    """Calculate the central tendencies of pairwise differences via bootstrapping.
+
+    This operation can take a long time, so the work is distributed over a
+    process pool to take advantage of multiple cores.
+
+    Parameters
+    ----------
+    samples
+        The timing samples for all input data classes
+    class1
+        The index of the first class to compare
+    class2
+        The index of the second class to compare
+    num_resamples
+        The number of resamplings to perform.
+    submit_job
+        Callable used to submit jobs to a process pool
+
+    Returns
+    -------
+    exact_central_tendencies
+        The central tendencies over the pairwise differences
+    bootstrapped_central_tendencies
+        The central tendencies for multiple resamplings of the pairwise differences
+    """
+
+    # Large values of 'num_resamples' would take a very long time to compute
+    # on a single thread, so we spread the load over multiple parallel workers
+    # to speed things up.
+    #
+    # Shared memory is to send the pairwise differences to the worker
+    # processes since this is much more efficient than pickling.
+
+    nsamples = samples.shape[0]
+    differences_buffer_size = nsamples * samples.itemsize
+    differences_mem = multiprocessing.shared_memory.SharedMemory(
+        create=True, size=differences_buffer_size
+    )
+
+    try:
+        differences = np.ndarray((nsamples,), samples.dtype, buffer=differences_mem.buf)
+        differences[:] = samples[:, class2] - samples[:, class1]
+
+        # Split the work into multiple parallel jobs. For data sets larger than
+        # 10 million the number of resamplings per job is limited to one resampling
+        # so that jobs finish quickly enough to regularly report progress.
+        # Otherwise, we scale the job to allow more work per job while still
+        # keeping a reasonable limit on the job duration.
+        if nsamples >= 1e7:
+            resamples_per_job = 1
+        else:
+            resamples_per_job = int(min(1e7 // nsamples, num_resamples))
+
+        job_sizes = [resamples_per_job] * (num_resamples // resamples_per_job)
+
+        last_partial_job_size = num_resamples % resamples_per_job
+        if last_partial_job_size > 0:
+            job_sizes.append(last_partial_job_size)
+
+        # Submit the jobs
+        futures = [
+            submit_job(
+                _central_tendencies_of_random_samples,
+                differences_mem,
+                differences.shape,
+                differences.dtype,
+                n,
+            )
+            for n in job_sizes
+        ]
+
+        # Compute the exact (non-resampled) central tendencies in parallel with
+        # the bootstrapping computation
+        q1, median, q3 = np.quantile(differences, [0.25, 0.5, 0.75])
+        exact_central_tendencies = {
+            "mean": np.mean(differences),
+            "median": median,
+            "trimmed_mean_5pc": scipy.stats.trim_mean(differences, 0.05),
+            "trimmed_mean_25pc": scipy.stats.trim_mean(differences, 0.25),
+            "trimmed_mean_45pc": scipy.stats.trim_mean(differences, 0.45),
+            "trimean": _trimean(q1, median, q3),
+        }
+
+        # Rejoin the results from each job back into a single dictionary
+        bootstrapped_central_tendencies = {}
+        for future in concurrent.futures.as_completed(futures):
+            job_result = future.result()
+
+            for key, values in job_result.items():
+                if key not in bootstrapped_central_tendencies:
+                    bootstrapped_central_tendencies[key] = values
+                else:
+                    bootstrapped_central_tendencies[key].extend(values)
+
+        return exact_central_tendencies, bootstrapped_central_tendencies
+    finally:
+        del differences
+        differences_mem.close()
+        differences_mem.unlink()
+
+
+def _confidence_interval_of_central_tendencies_of_differences(
+    samples_bin: BinarySamplesFileLoader,
+    class1: int,
+    class2: int,
+    num_resamples: int,
+    confidence_level: float,
+    submit_job: Callable[[Callable, Any], concurrent.futures.Future],
+) -> Dict[str, Tuple[float, float, float]]:
+    """Calculate the confidence interval of central tendencies of pairwise
+    differences via bootstrapping.
+
+    Parameters
+    ----------
+    samples
+        The samples for all classes.
+    class1
+        The index of the first class to compare in 'samples'.
+    class2
+        The index of the second class to compare in 'samples'.
+    num_resamples
+        The number of resamplings to perform for bootstrapping.
+    confidence_level
+        The confidence level to use (e.g. 0.95 for 95% confidence).
+    submit_job
+        Callable used to submit jobs to a process pool
+
+    Returns
+    -------
+    The confidence intervals for each of the central tendencies. Each confidence
+    interval is a tuple of the CI lower bound, exact value, and CI upper bound.
+    """
+
+    with samples_bin.load_samples() as samples:
+        (
+            exact_central_tendencies,
+            bootstrapped_central_tendencies,
+        ) = _bootstrap_central_tendencies_of_differences(
+            samples=samples,
+            class1=class1,
+            class2=class2,
+            num_resamples=num_resamples,
+            submit_job=submit_job,
+        )
+
+    # Calculate the confidence interval for each of the central tendency statistics
+    confidence_intervals = {}
+    for key, value in exact_central_tendencies.items():
+        lower = (1 - confidence_level) / 2
+        upper = 1 - (1 - confidence_level) / 2
+        quantiles = np.quantile(bootstrapped_central_tendencies[key], [lower, upper])
+
+        confidence_intervals[key] = (quantiles[0], value, quantiles[1])
+
+    return confidence_intervals, bootstrapped_central_tendencies
+
+
+def _draw_confidence_interval_plots(
+    output_dir: Path,
+    confidence_intervals_futures: Dict[Tuple[int, int], concurrent.futures.Future],
+):
+    """Generate the confidence interval plots
+
+    This also outputs the bootstrapped central tendencies data in CSV format.
+
+    Parameters
+    ----------
+    output_dir
+        The directory to where the outputs are generated
+    confidence_interval_futures
+        Contains the futures for the bootstrapped confidence interval interval data.
+        The keys are a tuple of two class indices and the values are the futures
+        for the CI computations for that class pair.
+    """
+
+    # Gather the data for each plot.
+    # The keys are the name of the central tendency e.g. "mean", "median", etc.
+    # The values are a DataFrame that contains the bootstrapped data for each class pair.
+    plots = {}
+    for (c1, c2), future in confidence_intervals_futures.items():
+
+        # Get return value of _confidence_interval_of_central_tendencies_of_differences
+        _, central_tendencies = future.result()
+
+        for name, data in central_tendencies.items():
+            if name not in plots:
+                plots[name] = pd.DataFrame()
+
+            plots[name][f"{c1} vs {c2}"] = data
+
+    # Generate a plot for each central tendency
+    for name, data in plots.items():
+        fig = Figure(figsize=(16, 12))
+        canvas = FigureCanvasAgg(fig)
+        ax = fig.add_subplot(1, 1, 1)
+        ax.violinplot(data, widths=0.7, showmeans=True, showextrema=True)
+        ax.set_xticks(list(range(len(data.columns) + 1)))
+        ax.set_xticklabels([" "] + list(data.columns))
+
+        if name == "trimmed_mean_5pc":
+            pretty_name = "trimmed mean (5%)"
+        elif name == "trimmed_mean_25pc":
+            pretty_name = "trimmed mean (25%)"
+        elif name == "trimmed_mean_45pc":
+            pretty_name = "trimmed mean (45%)"
+        else:
+            pretty_name = name
+
+        ax.set_title(f"Confidence intervals for {pretty_name} of pairwise differences")
+        ax.set_xlabel("Class pairs")
+        ax.set_ylabel(f"{pretty_name} of pairwise differences\n(cycles)")
+
+        canvas.print_figure(
+            output_dir / f"conf_interval_plot_{name}.png",
+            bbox_inches="tight",
+        )
+
+        with open(output_dir / f"bootstrapped_{name}.csv", "w") as f:
+            writer = csv.writer(f, lineterminator="\n")
+            writer.writerow(data.columns)
+            writer.writerows(data.itertuples(index=False))
+
+
 def _timing_leakage_detected(
     friedman_future: Optional[concurrent.futures.Future],
     class_pair_futures: Dict[Tuple[int, int], concurrent.futures.Future],
@@ -409,6 +713,8 @@ def _print_summary(
     class_pair_futures: Dict[Tuple[int, int], concurrent.futures.Future],
     friedman_future: Optional[concurrent.futures.Future],
     alpha: float,
+    confidence_level: float,
+    confidence_intervals_futures: Dict[Tuple[int, int], concurrent.futures.Future],
 ):
     """Print a summary of the results to the standard output
 
@@ -427,22 +733,56 @@ def _print_summary(
     -------
     True if evidence of timing leakage was found, or False otherwise.
     """
-    worst_class_pair, worst_results = _worst_pair(class_pair_futures)
+    worst_pair, worst_results = _worst_pair(class_pair_futures)
 
     if friedman_future is not None:
         print(f"Friedman test p-value: {friedman_future.result().pvalue}")
 
-    print(f"Worst pair: class {worst_class_pair[0]} and class {worst_class_pair[1]}")
+    print(f"Worst pair: class {worst_pair[0]} and class {worst_pair[1]}")
     print(f"\tWilcoxon signed-rank test p-value: {worst_results['wilcoxon'].pvalue}")
     print(f"\tt-test p-value: {worst_results['ttest'].pvalue}")
     print(f"\tsign test p-value: {worst_results['sign_test'].pvalue}")
 
+    if worst_pair in confidence_intervals_futures:
+        confidence_intervals, _ = confidence_intervals_futures[worst_pair].result()
+        max_ci = max(
+            (confidence_intervals[key][2] - confidence_intervals[key][0]) / 2
+            for key in [
+                "mean",
+                "trimmed_mean_5pc",
+                "trimmed_mean_25pc",
+                "trimmed_mean_45pc",
+            ]
+        )
+    else:
+        max_ci = None
+
     has_leakage = _timing_leakage_detected(friedman_future, class_pair_futures, alpha)
     print()
     if has_leakage:
-        print("Result: Timing leakage detected. Implementation is VULNERABLE.")
+        print("Result: Timing leakage DETECTED. Implementation is VULNERABLE.")
+    elif max_ci is None:
+        print(
+            "Result: No timing leakage was found, "
+            "but cannot be certain that the code is free from timing side "
+            "channels because the confidence interval calculation was skipped."
+        )
+    elif max_ci < 1.0:
+        # The code is considered to be constant time when the
+        print(
+            f"Result: No timing leakage was found. The confidence interval suggests "
+            f"that the code is free from timing side channels "
+            f"(side channel signal is less than {max_ci:.3f} cycles with "
+            f"{confidence_level * 100.0:.1f}% confidence)."
+        )
     else:
-        print("Result: Timing leakage not found. Code *might* be constant time.")
+        # Side channel signal is more than 1 cycle, so timing leakage could be
+        # possible.
+        print(
+            f"Result: No timing leakage was found, but the confidence interval suggests "
+            f"that timing leakage up to {max_ci:.3f} cycles could be possible."
+        )
+        print("More data is needed to confirm that the code is constant time.")
 
     return has_leakage
 
@@ -451,10 +791,13 @@ def analyse(
     samples_bin: BinarySamplesFileLoader,
     output_dir: Optional[Path],
     alpha: float = 1e-5,
+    confidence_level: Optional[float] = 0.95,
+    num_resamples: int = 5000,
     skip_friedman: bool = False,
+    ci_plot_all: bool = False,
     max_workers: Optional[int] = None,
 ):
-    """Run all statistical tests.
+    """Run all statistical tests and generate various output plots
 
     The statistical tests are run in multiple worker processes to take advantage
     of multiple cores to speed up the analysis.
@@ -470,8 +813,20 @@ def analyse(
         Directory where the output files should be generated.
     alpha
         The threshold for statistical significance.
+    confidence_level
+        Confidence level to use. If this is None then the confidence interval
+        calculations are skipped.
+    num_resamples
+        Number of resamplings to use when bootstrapping the confidence interval.
     skip_friedman
         When True, don't run the Friedman test.
+    ci_plot_all:
+        When True, a confidence interval will be bootstrapped for all pairs of
+        input data classes. Note that this will *significantly* increase the
+        analysis time.
+    max_workers:
+        Maximum number of worker subprocesses to use. If None, this will use
+        all available cores on the machine.
 
     Returns
     -------
@@ -480,7 +835,18 @@ def analyse(
     nsamples = samples_bin.nsamples
     nclasses = samples_bin.nclasses
 
-    progbar = progress.bar.Bar("Processing...", max=0)
+    # The analysis can take a very long time, so use progress bars to
+    # show some feedback to the user.
+    manager = enlighten.get_manager()
+    manager.no_resize = True
+    stats_progbar = manager.counter(total=0, desc="Statistical tests")
+    plots_progbar = manager.counter(total=0, desc="Generating Plots ")
+    if confidence_level is not None:
+        ci_progbar = manager.counter(total=0, desc="Conf. Intervals  ")
+        boots_progbar = manager.counter(total=0, desc="Bootstrapping CI ")
+
+    # Protects the progress bars when updating from multiple threads
+    progbar_lock = threading.Lock()
 
     # Some analyses can take a considerable amount of time, so we run them
     # in parallel to take advantage of multiple cores. Separate processes
@@ -488,13 +854,15 @@ def analyse(
 
     with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as proc_pool:
 
-        def submit_proc_pool_job(fn, *args, **kwargs):
-            """Submit a job to the process pool and advance the progress bar
+        def submit_proc_pool_job(progbar, fn, *args, **kwargs):
+            """Submit a job to the process pool and advance a progress bar
             when the job is done.
             """
             future = proc_pool.submit(fn, *args, **kwargs)
-            progbar.max += 1
-            future.add_done_callback(lambda _: progbar.next())
+            with progbar_lock:
+                progbar.total += 1
+                progbar.refresh()
+            future.add_done_callback(lambda _: progbar.update())
             return future
 
         # A thread pool is used for most things that need to wait on results
@@ -502,11 +870,25 @@ def analyse(
         # block on futures without the risk of deadlocks.
 
         with concurrent.futures.ThreadPoolExecutor() as thread_pool:
+
+            def submit_thread_pool_job(progbar, fn, *args, **kwargs):
+                """Submit a job to the thread pool and advance a progress bar
+                when the job is done.
+                """
+                future = thread_pool.submit(fn, *args, **kwargs)
+                with progbar_lock:
+                    progbar.total += 1
+                    progbar.refresh()
+                future.add_done_callback(lambda _: progbar.update())
+                return future
+
             # scipy's Friedman test uses the chi square approximation which
             # requires at least 3 sets of samples and more than 10 samples in
             # each set, so we skip this test if these conditions aren't met.
             if (not skip_friedman) and nsamples > 10 and nclasses >= 3:
-                friedman_future = submit_proc_pool_job(_friedman_test, samples_bin)
+                friedman_future = submit_proc_pool_job(
+                    stats_progbar, _friedman_test, samples_bin
+                )
             else:
                 friedman_future = None
 
@@ -515,17 +897,26 @@ def analyse(
             for c1 in range(nclasses):
                 for c2 in range(c1 + 1, nclasses):
                     class_pair_futures[(c1, c2)] = submit_proc_pool_job(
-                        _class_pair_statistics, samples_bin, c1, c2
+                        stats_progbar, _class_pair_statistics, samples_bin, c1, c2
                     )
 
             submit_proc_pool_job(
-                _draw_samples_scatter_plot, output_dir / "scatter_plot.png", samples_bin
+                plots_progbar,
+                _draw_samples_scatter_plot,
+                output_dir / "scatter_plot.png",
+                samples_bin,
             )
             submit_proc_pool_job(
-                _draw_classes_box_plot, output_dir / "box_plot.png", samples_bin
+                plots_progbar,
+                _draw_classes_box_plot,
+                output_dir / "box_plot.png",
+                samples_bin,
             )
             submit_proc_pool_job(
-                _draw_class_means_plot, output_dir / "class_means.png", samples_bin
+                plots_progbar,
+                _draw_class_means_plot,
+                output_dir / "class_means.png",
+                samples_bin,
             )
 
             thread_pool.submit(
@@ -534,13 +925,55 @@ def analyse(
                 class_pair_futures,
             )
 
+            # Determine which class pairs to bootstrap a confidence interval.
+            ci_class_pairs = []
+            if confidence_level is not None:
+                if ci_plot_all:
+                    for c1 in range(nclasses):
+                        for c2 in range(c1 + 1, nclasses):
+                            ci_class_pairs.append((c1, c2))
+                else:
+                    worst_pair, _ = _worst_pair(class_pair_futures)
+                    ci_class_pairs.append(worst_pair)
+
+            # Submit the jobs for the confidence intervals
+            confidence_intervals_futures = {}
+            for c1, c2 in ci_class_pairs:
+                confidence_intervals_futures[(c1, c2)] = submit_thread_pool_job(
+                    ci_progbar,
+                    _confidence_interval_of_central_tendencies_of_differences,
+                    samples_bin=samples_bin,
+                    class1=c1,
+                    class2=c2,
+                    num_resamples=num_resamples,
+                    confidence_level=confidence_level,
+                    submit_job=lambda fn, *args: submit_proc_pool_job(
+                        boots_progbar, fn, *args
+                    ),
+                )
+
+            if len(ci_class_pairs) > 0:
+                submit_thread_pool_job(
+                    plots_progbar,
+                    _draw_confidence_interval_plots,
+                    output_dir=output_dir,
+                    confidence_intervals_futures=confidence_intervals_futures,
+                )
+
             # Wait for everything to finish
             thread_pool.shutdown(wait=True)
             proc_pool.shutdown(wait=True)
 
-            # The progress bar doesn't put a newline at its end, so we put one here
-            print()
-            return _print_summary(class_pair_futures, friedman_future, alpha)
+            has_leakage = _print_summary(
+                class_pair_futures,
+                friedman_future,
+                alpha,
+                confidence_level,
+                confidence_intervals_futures,
+            )
+
+    manager.stop()
+    return has_leakage
 
 
 def _main():
@@ -572,6 +1005,39 @@ def _main():
         type=float,
         default=1e-5,
         help="Threshold for probability of a false positive",
+    )
+    parser.add_argument(
+        "-c",
+        "--conf-level",
+        nargs="?",
+        type=float,
+        default=0.95,
+        help=(
+            "Confidence level to use for the confidence interval. "
+            "E.g. 0.95 means 95% confidence."
+        ),
+    )
+    parser.add_argument(
+        "--ci-all-classes",
+        action="store_true",
+        default=False,
+        help=(
+            "Calculate the confidence interval for all class pairs "
+            "(warning: *significantly* increases analysis time)"
+        ),
+    )
+    parser.add_argument(
+        "--no-ci",
+        action="store_true",
+        default=False,
+        help="Skip confidence interval calculation"
+    )
+    parser.add_argument(
+        "-r",
+        "--resamples",
+        nargs="?",
+        default=5000,
+        help="Number of resamplings to use for bootstrapping the confidence interval",
     )
     parser.add_argument(
         "FILE",
@@ -606,7 +1072,10 @@ def _main():
             samples_bin,
             output_dir=output_dir,
             skip_friedman=args.no_friedman,
+            ci_plot_all=args.ci_all_classes and not args.no_ci,
             alpha=args.alpha,
+            confidence_level=args.conf_level if not args.no_ci else None,
+            num_resamples=args.resamples,
             max_workers=args.jobs,
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+enlighten>=1.12.4
+matplotlib>=3.8.2
+numpy>=1.26.4
+pandas>=2.2.0
+scipy>=1.12.0


### PR DESCRIPTION
The analyse script now computes confidence intervals to determine whether enough data has been collected to exclude the possibility of a timing side channel if the CI is less than 1 cycle, and the existing statistical tests don't find timing leakage.

The confidence interval is bootstrapped on the pairwise differences of the worst class pair (i.e. the pair with the lowest p-value), with a confidence level of 95% by default.

The progress bar has been switched over to the enlighten library so that multiple progress bars can be shown for the various parallel computations.